### PR TITLE
Create resilient test coverage collection

### DIFF
--- a/tga-core/src/main/kotlin/org/plan/research/tga/core/tool/TestSuite.kt
+++ b/tga-core/src/main/kotlin/org/plan/research/tga/core/tool/TestSuite.kt
@@ -10,5 +10,7 @@ data class TestSuite(
     @Serializable(with = PathAsStringSerializer::class)
     val testSrcPath: Path,
     val tests: List<String>,
+    val testCasesOnly: List<String>,
+    val testSuiteQualifiedName: String,
     val dependencies: List<Dependency>,
 )

--- a/tga-runner/src/main/kotlin/org/plan/research/tga/runner/coverage/jacoco/JacocoCoverageProvider.kt
+++ b/tga-runner/src/main/kotlin/org/plan/research/tga/runner/coverage/jacoco/JacocoCoverageProvider.kt
@@ -25,6 +25,7 @@ import org.plan.research.tga.core.tool.TestSuite
 import org.plan.research.tga.runner.compiler.SystemJavaCompiler
 import org.vorpal.research.kfg.Package
 import org.vorpal.research.kthelper.deleteOnExit
+import org.vorpal.research.kthelper.logging.debug
 import org.vorpal.research.kthelper.logging.error
 import org.vorpal.research.kthelper.logging.log
 import org.vorpal.research.kthelper.tryOrNull
@@ -60,13 +61,56 @@ class JacocoCoverageProvider(
     }
 
     override fun computeCoverage(benchmark: Benchmark, testSuite: TestSuite): ClassCoverageInfo {
+        log.debug("Computing coverage: compiledDir='{}'", compiledDir)
+
+        // set of sources containing both test cases and the test suite
         val allTests = testSuite.tests.associateWith { testSuite.testSrcPath.resolve(it.asmString + ".java") }
+        // set of sources containing the single test suite
+        val testSuiteOnly = if (testSuite.testSuiteQualifiedName.isNotEmpty()) {
+            testSuite.testSuiteQualifiedName.let { testSuiteName ->
+                listOf(testSuiteName).associateWith { testSuite.testSrcPath.resolve(it.asmString + ".java") }
+            }
+        } else {
+            null
+        }
+        // set of sources containing only test cases without the test suite
+        val testCasesOnly = if (testSuite.testCasesOnly.isNotEmpty()) {
+                testSuite.testCasesOnly.associateWith { testSuite.testSrcPath.resolve(it.asmString + ".java") }
+            } else {
+                null
+            }
+
+        /**
+         * Provide up to 3 sets of source files suitable for compilation and
+         * try to collect coverage for at least one of them since all 3 represent
+         * the same coverage set:
+         * 1. All the compilable test cases and the test suite (test suite contains only compilable test cases).
+         * 2. All the compilable test case alone.
+         * 3. The test suite alone.
+         */
+        val compilationAttempts = mutableListOf(allTests)
+        testSuiteOnly?.also { compilationAttempts.add(it) }
+        testCasesOnly?.also { compilationAttempts.add(it) }
+
         val classPath = benchmark.classPath + testSuite.dependencies.flatMap { dependencyManager.findDependency(it) }
         val compiler = SystemJavaCompiler(classPath)
-        try {
-            compiler.compile(allTests.values.toList(), compiledDir)
-        } catch (e: Throwable) {
-            log.error(e)
+
+        for ((index, attempt) in compilationAttempts.withIndex()) {
+            log.debug(
+                "Attempting to compile {}-th set of tests: [\n{}\n\t]",
+                index,
+                attempt.keys.joinToString(separator = "\n") { "\t\t$it," },
+            )
+
+            try {
+                val result = compiler.compile(attempt.values.toList(), compiledDir)
+                log.debug("Compilation succeeded with result: {}", result)
+                break
+            }
+            catch (e: Throwable) {
+                log.error(e)
+                // TODO: should compiledDir be cleaned up before next attempt?
+            }
         }
 
         val runtime = LoggerRuntime()

--- a/tga-tool/src/main/kotlin/org/plan/research/tga/tool/kex/KexCliTool.kt
+++ b/tga-tool/src/main/kotlin/org/plan/research/tga/tool/kex/KexCliTool.kt
@@ -65,6 +65,8 @@ class KexCliTool(private val args: List<String>) : TestGenerationTool {
         return TestSuite(
             testSrcPath,
             tests,
+            emptyList(),
+            "",
             listOf(
                 Dependency("junit", "junit", "4.13.2")
             )

--- a/tga-tool/src/main/kotlin/org/plan/research/tga/tool/stub/StubTool.kt
+++ b/tga-tool/src/main/kotlin/org/plan/research/tga/tool/stub/StubTool.kt
@@ -28,6 +28,6 @@ class StubTool : TestGenerationTool {
     }
 
     override fun report(): TestSuite {
-        return TestSuite(testDir, emptyList(), emptyList())
+        return TestSuite(testDir, emptyList(), emptyList(), "", emptyList())
     }
 }

--- a/tga-tool/src/main/kotlin/org/plan/research/tga/tool/testspark/TestSparkCliTool.kt
+++ b/tga-tool/src/main/kotlin/org/plan/research/tga/tool/testspark/TestSparkCliTool.kt
@@ -158,7 +158,7 @@ class TestSparkCliTool(args: List<String>) : TestGenerationTool {
         val testSrcPath = outputDirectory
         val tests = getCompilableTestCases(testSrcPath)
         val testCasesOnly = tests.filter { test -> !test.endsWith("GeneratedTest") }
-        val testSuite = tests.first { test -> test.endsWith("GeneratedTest") }
+        val testSuite = tests.firstOrNull { test -> test.endsWith("GeneratedTest") } ?: ""
 
         log.debug("Compilable tests {}: {}", tests.size, tests)
         log.debug("Compilable test cases {}: {}", testCasesOnly.size, testCasesOnly)

--- a/tga-tool/src/main/kotlin/org/plan/research/tga/tool/testspark/TestSparkCliTool.kt
+++ b/tga-tool/src/main/kotlin/org/plan/research/tga/tool/testspark/TestSparkCliTool.kt
@@ -9,7 +9,9 @@ import org.plan.research.tga.core.tool.TestSuite
 import org.vorpal.research.kthelper.assert.unreachable
 import org.vorpal.research.kthelper.logging.log
 import org.vorpal.research.kthelper.resolve
+import java.io.BufferedReader
 import java.io.File
+import java.io.InputStreamReader
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -133,7 +135,16 @@ class TestSparkCliTool(args: List<String>) : TestGenerationTool {
             )
             log.debug("Starting TestSpark with command: {}", processBuilder.command())
 
+            processBuilder.redirectErrorStream(true)
             process = processBuilder.start()!!
+
+            log.debug("Configure reader for the TestSpark process")
+
+            val reader = BufferedReader(InputStreamReader(process.inputStream))
+            var line = ""
+            while (reader.readLine()?.also { line = it } != null) {
+                println(line)
+            }
             log.debug("Waiting for the TestSpark process...")
             process.waitFor()
             log.debug("TestSpark process has merged")


### PR DESCRIPTION
# Description:
To make the coverage collection robust and resilient we make 3 attempts of compilation and further coverage collection for the first compilation attempt that succeeds. All of the 3 attempts will result in the same coverage if succeed since they represent the following sets (in the this order):

1. The set of compilable test cases and the test suite.
2. The test suite only.
3. The set of compilable test cases only.

In order to support these 3 sets I added 2 more fields in the `testSuite.json` files:

<img width="775" alt="Screenshot 2024-04-17 at 00 16 19" src="https://github.com/plan-research/tga-pipeline/assets/47076189/83f9663c-33e0-4cbe-a0ed-c58941fed7bb">

For the Kex I merely set them to be an empty array `[]` and an empty string `""`. I assume that Kex works similar to the EvoSuite, thus all of its test cases are compilable by default, so there 2 additional fields are only required for TestSpark.

# Notes
1. I changed the prompt parameter to be a path to the file with the prompt. I did not find a way to specify this argument in the IntelliJ configuration settings otherwise.
2. There is a single **TODO**. **Please, read it.**

**Question:** if the compilation fails, does it mean that no `.class`-files were produced in the `compiledDir` directory? If so, then no deletion needed and the TODO may be removed. 

