### PR TITLE
Early timeout leads to uncertain and incorrect benchmark request terminations.

### DIFF
--- a/tga-tool/src/main/kotlin/org/plan/research/tga/tool/ToolController.kt
+++ b/tga-tool/src/main/kotlin/org/plan/research/tga/tool/ToolController.kt
@@ -9,6 +9,7 @@ import org.plan.research.tga.core.tool.protocol.Tool2TgaConnection
 import org.vorpal.research.kthelper.logging.log
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 import kotlin.time.measureTime
 
 
@@ -35,7 +36,7 @@ class ToolController(
                 is BenchmarkRequest -> {
                     tool.init(request.benchmark.root, request.benchmark.classPath)
 
-                    val hardTimeout = request.timeLimit * 2
+                    val hardTimeout = maxOf(request.timeLimit * 2, Duration.parse("40s"))
                     val generationTime = measureTime {
                         val execution = executorService.submit {
                             tool.run(

--- a/tga-tool/src/main/kotlin/org/plan/research/tga/tool/evosuite/EvoSuiteCliTool.kt
+++ b/tga-tool/src/main/kotlin/org/plan/research/tga/tool/evosuite/EvoSuiteCliTool.kt
@@ -67,6 +67,7 @@ class EvoSuiteCliTool : TestGenerationTool {
             outputDirectory.resolve(EVOSUITE_LOG).bufferedWriter().use { writer ->
                 val reader = BufferedReader(InputStreamReader(process.inputStream))
                 while (true) {
+                    if (Thread.currentThread().isInterrupted) throw InterruptedException()
                     val line = reader.readLine() ?: break
                     writer.write(line)
                     writer.write("\n")

--- a/tga-tool/src/main/kotlin/org/plan/research/tga/tool/testspark/TestSparkCliTool.kt
+++ b/tga-tool/src/main/kotlin/org/plan/research/tga/tool/testspark/TestSparkCliTool.kt
@@ -147,6 +147,7 @@ $POLYMORPHISM"""
             outputDirectory.resolve(TEST_SPARK_LOG).bufferedWriter().use { writer ->
                 val reader = BufferedReader(InputStreamReader(process.inputStream))
                 while (true) {
+                    if (Thread.currentThread().isInterrupted) throw InterruptedException()
                     val line = reader.readLine() ?: break
                     writer.write(line)
                     writer.write("\n")


### PR DESCRIPTION
### Problem
I discovered a strange behaviour, namely that TGA-Pipeline does not produce results for all experiment runs, although it should when setting the search budget of my EvoSuite experiments to a small amount like 5 seconds. 

### Cause and consequences
I suspect that this behaviour is caused by a small hard timeout (e.g. 5s x 2 = the 10s) which is not high enough for the process to finish executing before another benchmark request starts. The process is also not guaranteed to be killed immediately by the TGA pipeline, although the pipeline does try to terminate it. This leads to the pipeline enqueuing another request while the other one is still running. Consequently, the second process has even less time before the timeout is reached; this seems to cascade down to the point where some runs might not start running before they are cancelled, and we send a result response specifying the output directory of the previous run. For example, in my case the pipeline reported that EvoSuite tool could not generate a test suite for the third run because the test suite which was sent as a result was the suite of run two. Sometimes it is the second run which is missing while the first and last a present.

I am not sure if this problem is only present when the experiment run time is less than 30 seconds, or if it could occur in some other conditions. This could also be a consequence of my Windows laptop being slower.

### Solution
The two simple solutions I have are:

- Set the hard time out value to be a minimum of 40 seconds or bigger. `val hardTimeout = maxOf(request.timeLimit * 2, Duration.parse("40s"))`
- Include a check for thread interruption in the configuration of the `bufferedWriter`.

Both of those versions seem to fix this specific error case I found, however, as I mentioned, I am unsure if there are other issues relating to this behaviour.

### Further concerns
I am mostly concerned with the fact that my patches do not ensure that all processes associated with the current benchmark request were completed. They only make it more likely that the processes were terminated before the start of another one. I wonder if maybe the run function should return some value instead of nothing as an indicator that it terminated the process and we can move on. I am also concerned that the minimum hard timeout was mostly hand picked to suit EvoSuite needs, what if it is different per each tool? Also, I do not know if my solution works for Kex and Jazzer because they do not have a loop where I can constantly check for thread interruptions. 

### Replication details
If you want to replicate the behaviour, you can try launching EvoSuite tool with a search budget of 5 seconds and with three repetitions. You can limit the benchmark json config file to a single benchmark. If the error persists, you will see that although you specified three runs (0..2), the output contained only two results. If you change the time budget to 30 seconds, the problem will go away.

- TGA-Runner command line: `--config Path/To/Benchmark/Config/JavaStellarSdkKeyPairConfig.json --output debugTimeOutError\ --port 40000 --runName test-debug-timeout-error --runs 0..2 --timeout 5`
- TGA-Tool command line: `--tool EvoSuite --ip localhost --port  #40000`
