### PR TITLE
Reduce images size and apply best practices

### DIFF
--- a/dockerfiles/benchmarks.docker
+++ b/dockerfiles/benchmarks.docker
@@ -11,7 +11,7 @@ RUN apt-get -y update \
 	python3 \
 	git \
 	&& rm -rf /var/lib/apt/lists/* \
-    && git clone https://github.com/gitbugactions/gitbug-java.git /root/gitbug-java
+	&& git clone https://github.com/gitbugactions/gitbug-java.git /root/gitbug-java
 
 # add scripts to container
 COPY ./scripts /var/scripts

--- a/dockerfiles/benchmarks.docker
+++ b/dockerfiles/benchmarks.docker
@@ -1,5 +1,5 @@
 FROM ubuntu:latest
-MAINTAINER Azat Abdullin <azat.aam@gmail.com>
+LABEL org.opencontainers.image.authors="Azat Abdullin <azat.aam@gmail.com>"
 
 # install required packages
 USER root

--- a/dockerfiles/benchmarks.docker
+++ b/dockerfiles/benchmarks.docker
@@ -3,23 +3,20 @@ MAINTAINER Azat Abdullin <azat.aam@gmail.com>
 
 # install required packages
 USER root
-RUN apt-get -y update
-RUN apt-get -y install \
+RUN apt-get -y update \
+	&& apt-get -y --no-install-recommends install \
 	openjdk-11-jdk \
 	maven \
 	gradle \
 	python3 \
-	git
-
-# clone gitbug repo
-RUN git clone https://github.com/gitbugactions/gitbug-java.git /root/gitbug-java
+	git \
+	&& rm -rf /var/lib/apt/lists/* \
+    && git clone https://github.com/gitbugactions/gitbug-java.git /root/gitbug-java
 
 # add scripts to container
 ADD ./scripts /var/scripts
 
 # run scripts and build benchmarks
-RUN python3 /var/scripts/gitbug_setup.py /root/gitbug-java /var/benchmarks/gitbug False
-RUN python3 /var/scripts/gitbug_setup.py /root/gitbug-java /var/benchmarks/gitbug-patched True
-
-# give access to all users
-RUN chmod a+wr -R /var/benchmarks
+RUN python3 /var/scripts/gitbug_setup.py /root/gitbug-java /var/benchmarks/gitbug False \
+	&& python3 /var/scripts/gitbug_setup.py /root/gitbug-java /var/benchmarks/gitbug-patched True \
+	&& chmod a+wr -R /var/benchmarks # give access to all users

--- a/dockerfiles/benchmarks.docker
+++ b/dockerfiles/benchmarks.docker
@@ -14,7 +14,7 @@ RUN apt-get -y update \
     && git clone https://github.com/gitbugactions/gitbug-java.git /root/gitbug-java
 
 # add scripts to container
-ADD ./scripts /var/scripts
+COPY ./scripts /var/scripts
 
 # run scripts and build benchmarks
 RUN python3 /var/scripts/gitbug_setup.py /root/gitbug-java /var/benchmarks/gitbug False \

--- a/dockerfiles/pipeline.docker
+++ b/dockerfiles/pipeline.docker
@@ -7,20 +7,19 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 
 # install additional packages
 USER root
-RUN apt-get update
-RUN apt-get -y install \
+RUN apt-get update \
+	&& apt-get --no-install-recommends -y install \
 	wget \
 	unzip \
 	curl \
 	gnupg \
-	apt-transport-https
-
-# installing bazel
-RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
-RUN mv bazel-archive-keyring.gpg /usr/share/keyrings
-RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN apt-get update
-RUN apt-get -y install bazel-7.3.0
+	apt-transport-https \
+	&& curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg \
+	&& mv bazel-archive-keyring.gpg /usr/share/keyrings \
+	&& echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
+	&& apt-get update \
+	&& apt-get --no-install-recommends -y install bazel-7.3.0 \
+	&& rm -rf /var/lib/apt/lists/*
 
 # install pipeline
 USER root

--- a/dockerfiles/pipeline.docker
+++ b/dockerfiles/pipeline.docker
@@ -1,5 +1,5 @@
 FROM abdullin/tga-pipeline:benchmarks-latest
-MAINTAINER Azat Abdullin <azat.aam@gmail.com>
+LABEL org.opencontainers.image.authors="Azat Abdullin <azat.aam@gmail.com>"
 
 ARG PIPELINE_VERSION=0.0.46
 

--- a/dockerfiles/runner.docker
+++ b/dockerfiles/runner.docker
@@ -1,5 +1,5 @@
 FROM abdullin/tga-pipeline:base-latest
-MAINTAINER Azat Abdullin <azat.aam@gmail.com>
+LABEL org.opencontainers.image.authors="Azat Abdullin <azat.aam@gmail.com>"
 
 # run pipeline
 USER root

--- a/dockerfiles/runner.docker
+++ b/dockerfiles/runner.docker
@@ -4,10 +4,7 @@ MAINTAINER Azat Abdullin <azat.aam@gmail.com>
 # run pipeline
 USER root
 WORKDIR /tga-pipeline
-RUN ./gradlew :tga-runner:build
-
-# give access to all users
-RUN chmod a+r -R /tga-pipeline
-RUN chmod a+w -R /tga-pipeline
+RUN ./gradlew :tga-runner:build \
+  && chmod a+rw -R /tga-pipeline
 
 ENTRYPOINT ["java", "-jar", "/tga-pipeline/tga-runner/build/libs/tga-runner.jar"]

--- a/dockerfiles/tools.docker
+++ b/dockerfiles/tools.docker
@@ -1,5 +1,5 @@
 FROM abdullin/tga-pipeline:base-latest
-MAINTAINER Azat Abdullin <azat.aam@gmail.com>
+LABEL org.opencontainers.image.authors="Azat Abdullin <azat.aam@gmail.com>"
 
 ARG KEX_VERSION=0.0.8
 ARG TEST_SPARK_COMMIT=aec399f79d0fc98daa21c214733e707db00f9048

--- a/dockerfiles/tools.docker
+++ b/dockerfiles/tools.docker
@@ -14,7 +14,7 @@ USER root
 WORKDIR /var/tools
 RUN mkdir kex
 WORKDIR /var/tools/kex
-RUN wget https://github.com/vorpal-research/kex/releases/download/$KEX_VERSION/kex-$KEX_VERSION.zip \
+RUN wget --progress=dot:giga https://github.com/vorpal-research/kex/releases/download/$KEX_VERSION/kex-$KEX_VERSION.zip \
     && unzip kex-$KEX_VERSION.zip
 ENV KEX_HOME=/var/tools/kex
 

--- a/dockerfiles/tools.docker
+++ b/dockerfiles/tools.docker
@@ -14,8 +14,8 @@ USER root
 WORKDIR /var/tools
 RUN mkdir kex
 WORKDIR /var/tools/kex
-RUN wget https://github.com/vorpal-research/kex/releases/download/$KEX_VERSION/kex-$KEX_VERSION.zip
-RUN unzip kex-$KEX_VERSION.zip
+RUN wget https://github.com/vorpal-research/kex/releases/download/$KEX_VERSION/kex-$KEX_VERSION.zip \
+    && unzip kex-$KEX_VERSION.zip
 ENV KEX_HOME=/var/tools/kex
 
 # install TestSpark
@@ -32,14 +32,14 @@ ENV TEST_SPARK_HOME=/var/tools/TestSpark
 # install Jazzer
 USER root
 WORKDIR /var
-RUN chmod a+w -R /var/tools
-RUN useradd -ms /bin/bash test
+RUN chmod a+w -R /var/tools \
+    && useradd -ms /bin/bash test
 USER test
 WORKDIR /var/tools
 RUN git clone https://github.com/AbdullinAM/jazzer.git
 WORKDIR /var/tools/jazzer
-RUN git checkout $JAZZER_COMMIT
-RUN bazel-7.3.0 build //:jazzer
+RUN git checkout $JAZZER_COMMIT \
+    && bazel-7.3.0 build //:jazzer
 ENV JAZZER_HOME=/var/tools/jazzer/bazel-bin/launcher/
 # RUN mkdir Jazzer
 # WORKDIR /var/tools/Jazzer
@@ -50,12 +50,8 @@ ENV JAZZER_HOME=/var/tools/jazzer/bazel-bin/launcher/
 # run tool
 USER root
 WORKDIR /tga-pipeline
-RUN ./gradlew :tga-tool:build
-
-# give access to all users
-RUN chmod a+r -R /tga-pipeline
-RUN chmod a+w -R /tga-pipeline
-RUN chmod a+r -R /var/tools
-RUN chmod a+w -R /var/tools
+RUN ./gradlew :tga-tool:build \
+    && chmod a+rw -R /tga-pipeline \
+    && chmod a+rw -R /var/tools
 
 ENTRYPOINT ["java", "-jar", "/tga-pipeline/tga-tool/build/libs/tga-tool.jar"]


### PR DESCRIPTION
This pull request includes several improvements to the Dockefiles used in the project to reduce the size and the number of layers for images, especially the benchmark one.

### Dockerfile Improvements:

* Combined multiple `RUN` commands into single lines using `&&` to reduce the number of layers, and reduce the size of images. [Docs](https://github.com/hadolint/hadolint/wiki/DL3059).
(`dockerfiles/benchmarks.docker`, `dockerfiles/pipeline.docker`, `dockerfiles/runner.docker`, `dockerfiles/tools.docker`).
* Added `--no-install-recommends` to `apt-get install` commands to avoid installing unnecessary packages and cleaned up `apt` lists to reduce image size. [Docs](https://docs.docker.com/build/building/best-practices/#apt-get).
(`dockerfiles/benchmarks.docker`, `dockerfiles/pipeline.docker`).
* Replaced `ADD` with `COPY` for copying files from host into the container. [Docs](https://docs.docker.com/build/building/best-practices/#add-or-copy).
(`dockerfiles/benchmarks.docker`).
* Updated the `MAINTAINER` directive to the `LABEL` directive for better compliance with the OCI image format. [Docs](https://docs.docker.com/reference/build-checks/maintainer-deprecated/).
(`dockerfiles/benchmarks.docker`, `dockerfiles/pipeline.docker`, `dockerfiles/runner.docker`, `dockerfiles/tools.docker`). 

## Notes

The most important changes are inside the `benchmark.docker` file when benchmark's projects are set up.
https://github.com/plan-research/tga-pipeline/blob/8924d374e01dfaf4ddd22f141c9a5d8c635ff09e/dockerfiles/benchmarks.docker#L20-L25

The last RUN command updates rights of all benchmark files. Because the same files have different rights between line 22 and line 25. Docker cannot use the cached version from the layer created at line 22. By combining the `chmod` with the previous commands, we avoid having the same file twice in the layers stack. 

We can compare the size of the two version on docker hub: [Original](https://hub.docker.com/layers/abdullin/tga-pipeline/benchmarks-0.0.46/images/sha256-f53d675df453732f2bed210ff5f21e8da71a39a4b4d63e9d35f440e61d460226) → [This version](https://hub.docker.com/layers/vsantele/tga-pipeline/benchmarks/images/sha256-7559500fbc0705c034a4e334dbceb0c23acbdb43b571c8d33633707187441267). We can see that the compressed size drops from 66.76GB to 37.89GB. The diff come from the 15th layer from the original image.

The decompressed image size is also lighter on the host.
![Original image on my computer](https://github.com/user-attachments/assets/49ace921-24ac-42d6-bf11-c22ecac04da0)
![This image's version on my computer](https://github.com/user-attachments/assets/bc23783c-c83e-41e2-abab-4cc47537f32a)


